### PR TITLE
Add Hard Fork 2019 API Endpoint

### DIFF
--- a/controllers/v2-controller.ts
+++ b/controllers/v2-controller.ts
@@ -19,7 +19,7 @@ import {
 } from '../lib/core-db-pg/queries';
 
 // const { blockToTime } = require('../lib/utils');
-import { blockToTime, stacksValue } from '../lib/utils';
+import { blockToTime, stacksValue, formatNumber } from '../lib/utils';
 
 const Controller = express.Router();
 
@@ -158,13 +158,14 @@ Controller.get('/genesis-2019/:stacksAddress', async (req: Request, res: Respons
       const vestingBlocks = Object.keys(account.vesting);
       const lastVestingMonth = blockToTime(vestingBlocks[vestingBlocks.length - 1]);
       account.unlockUntil = moment(lastVestingMonth).format('MMMM Do, YYYY');
-      account.totalFormatted = accounting.formatNumber(stacksValue(account.value + account.vesting_total));
-      account.unlockPerMonthFormatted = accounting.formatNumber(stacksValue(account.vesting[vestingBlocks[0]]));
+      account.totalFormatted = formatNumber(stacksValue(account.value + account.vesting_total));
+      account.unlockPerMonthFormatted = formatNumber(stacksValue(account.vesting[vestingBlocks[0]]));
       return account;
     });
-    const totalFormatted = accounting.formatNumber(stacksValue(total));
+    const totalFormatted = formatNumber(stacksValue(total));
     res.json({ accounts, total, totalFormatted });
   } catch (error) {
+    console.error(error);
     res.status(404).json({ success: false });
   }
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,22 @@
 /* eslint-disable prefer-destructuring */
 const moment = require('moment');
+const accounting = require('accounting');
 
 export const stacksValue = value => +`${Math.round(`${value * 10e-7}e+7`)}e-7`;
 export const btcValue = value => +`${Math.round(`${value * 10e-9}e+9`)}e-9`;
+
+export const formatNumber = (value) => {
+  const formatted = accounting.formatNumber(value, 8);
+  const decimals = formatted.split('.')[1];
+  let precision = 8;
+  decimals.split('').reverse().some((char) => {
+    if (char === '0') {
+      precision -= 1;
+    }
+    return char !== '0';
+  });
+  return accounting.formatNumber(value, precision);
+};
 
 const startBlock = 538161;
 const start = moment(1535059015 * 1000);
@@ -58,6 +72,7 @@ export const extractRootDomain = (url) => {
 module.exports = {
   stacksValue,
   blockToTime,
+  formatNumber,
   btcValue,
   extractHostname,
   extractRootDomain,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test-watch": "NODE_ENV=test jest --verbose=false --ci --watch"
   },
   "devDependencies": {
+    "@types/accounting": "^0.4.1",
     "@types/cors": "^2.8.4",
     "@types/express": "^4.16.1",
     "@types/jest": "^24.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,6 +337,11 @@
   dependencies:
     "@sentry/types" "4.3.0"
 
+"@types/accounting@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/accounting/-/accounting-0.4.1.tgz#865d9f5694fd7c438fba34eb4bc82eec6f34cdd5"
+  integrity sha512-qIN2yvRFvTtUtzG3bs7NKnsqHCPwRIIZMvBNWxiyF4LfOBMhwbwmsefqOt1T7KfkvCgOOxWYVqvlnKKZARSHgg==
+
 "@types/babel__core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.0.tgz#710f2487dda4dcfd010ca6abb2b4dc7394365c51"


### PR DESCRIPTION
This PR adds one API endpoint to implement a self-service hard fork 2019 audit feature, whereby users can query their addresses and see their STX allocations.