### PR TITLE
Top balances / rich list API endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,11 @@
               "--detectOpenHandles",
               "--config",
               "${workspaceRoot}/jest.config.js"
-            ]
+            ],
+            "console": "integratedTerminal",
+            "env": {
+                "NODE_ENV": "development"
+            }
           }
     ]
 }

--- a/lib/aggregators/top-balances.ts
+++ b/lib/aggregators/top-balances.ts
@@ -1,9 +1,11 @@
+import * as c32check from 'c32check';
 import Aggregator from './aggregator';
 import { getUnlockedSupply, getTopBalances } from '../core-db-pg/queries';
 import { microStacksToStacks } from '../utils';
 
 export interface TopBalanceAccount {
-  address: string;
+  stxAddress: string;
+  btcAddress: string;
   balance: string;
   distribution: number;
 }
@@ -21,7 +23,8 @@ class TopBalancesAggregator extends Aggregator {
     const { unlockedSupply } = await getUnlockedSupply();
     const topBalances = await getTopBalances(count);
     return topBalances.map(account => ({
-      address: account.address,
+      stxAddress: c32check.b58ToC32(account.address),
+      btcAddress: account.address,
       balance: microStacksToStacks(account.balance),
       distribution: parseFloat(account.balance.div(unlockedSupply).multipliedBy(100).toFixed(6)),
     }));

--- a/lib/aggregators/top-balances.ts
+++ b/lib/aggregators/top-balances.ts
@@ -1,0 +1,31 @@
+import Aggregator from './aggregator';
+import { getUnlockedSupply, getTopBalances } from '../core-db-pg/queries';
+import { microStacksToStacks } from '../utils';
+
+export interface TopBalanceAccount {
+  address: string;
+  balance: string;
+  distribution: number;
+}
+
+class TopBalancesAggregator extends Aggregator {
+  static key(count: number) {
+    return `${this.name}:${count}`;
+  }
+
+  static expiry() {
+    return 10 * 60; // 10 minutes
+  }
+
+  static async setter(count: number): Promise<TopBalanceAccount[]> {
+    const { unlockedSupply } = await getUnlockedSupply();
+    const topBalances = await getTopBalances(count);
+    return topBalances.map(account => ({
+      address: account.address,
+      balance: microStacksToStacks(account.balance),
+      distribution: parseFloat(account.balance.div(unlockedSupply).multipliedBy(100).toFixed(6)),
+    }));
+  }
+}
+
+export default TopBalancesAggregator;

--- a/lib/core-db-pg/queries.ts
+++ b/lib/core-db-pg/queries.ts
@@ -250,11 +250,7 @@ export interface BalanceInfo {
   balance: BigNumber;
 }
 
-export async function getTopBalances(count = 250): Promise<BalanceInfo[]> {
-  const MAX_COUNT = 500;
-  if (count > MAX_COUNT) {
-    throw new Error(`Max count of ${MAX_COUNT} exceeded`);
-  }
+export async function getTopBalances(count: number): Promise<BalanceInfo[]> {
   const sql = `
     SELECT * FROM (
       SELECT DISTINCT ON (address) address, (CAST(credit_value AS bigint) - CAST(debit_value AS bigint)) as balance

--- a/lib/core-db-pg/queries.ts
+++ b/lib/core-db-pg/queries.ts
@@ -245,6 +245,39 @@ export async function getUnlockedSupply(): Promise<UnlockedSupply> {
   };
 }
 
+export interface BalanceInfo {
+  address: string;
+  balance: BigNumber;
+}
+
+export async function getTopBalances(count = 250): Promise<BalanceInfo[]> {
+  const MAX_COUNT = 500;
+  if (count > MAX_COUNT) {
+    throw new Error(`Max count of ${MAX_COUNT} exceeded`);
+  }
+  const sql = `
+    SELECT * FROM (
+      SELECT DISTINCT ON (address) address, (CAST(credit_value AS bigint) - CAST(debit_value AS bigint)) as balance
+          FROM accounts 
+          WHERE type = 'STACKS' 
+          AND address !~ '(-|_)' 
+          AND length(address) BETWEEN 33 AND 34 
+          AND receive_whitelisted = '1' 
+          AND lock_transfer_block_id <= (SELECT MAX(block_id) from accounts)
+          ORDER BY address, block_id DESC, vtxindex DESC
+    ) as balances
+    ORDER BY balance DESC
+    LIMIT $1`;
+  const db = await getDB();
+  const params = [count];
+  const { rows } = await db.query(sql, params);
+  const balances: BalanceInfo[] = rows.map(row => ({
+    address: row.address,
+    balance: new BigNumber(row.balance),
+  }));
+  return balances;
+}
+
 export const getHistoryFromTxid = async (txid: string): Promise<HistoryRecord | null> => {
   const sql = 'SELECT * from history where txid = $1';
   const params = [txid];

--- a/test/aggregators/stacks-address.test.ts
+++ b/test/aggregators/stacks-address.test.ts
@@ -1,16 +1,5 @@
 import '../setup';
 import StacksAddress from '../../lib/aggregators/stacks-address';
-import TopBalancesAggregator, { TopBalanceAccount } from '../../lib/aggregators/top-balances';
-
-test('get top balances', async () => {
-  const balances: TopBalanceAccount[] = await TopBalancesAggregator.fetch(500);
-  expect(balances.length).toEqual(500);
-  expect(balances[0].address).toBeTruthy();
-  expect(parseFloat(balances[0].balance)).toBeGreaterThan(1);
-  const totalDistribution = balances.reduce((total, account) => total + account.distribution, 0);
-  // Sanity check on the combined distribution percentages of the top accounts
-  expect(totalDistribution).toBeGreaterThan(50);
-});
 
 test('can get basic STX address info', async () => {
   const account = await StacksAddress.setter('SPCFS0TX3MS91928283R36V2G14BGKSMVE3FMN93');

--- a/test/aggregators/stacks-address.test.ts
+++ b/test/aggregators/stacks-address.test.ts
@@ -1,8 +1,23 @@
 import '../setup';
 import BN from 'bn.js';
+import BigNumber from 'bignumber.js';
 import StacksAddress from '../../lib/aggregators/stacks-address';
-import { getUnlockedSupply } from '../../lib/core-db-pg/queries';
+import { getUnlockedSupply, getTopBalances } from '../../lib/core-db-pg/queries';
 
+test('get top balances', async () => {
+  const { unlockedSupply } = await getUnlockedSupply();
+  const balances = await getTopBalances(500);
+  expect(balances).toBeTruthy();
+  expect(balances.length).toEqual(500);
+  expect(balances[0].address).toBeTruthy();
+  expect(balances[0].balance.gt(1)).toBeTruthy();
+
+  const distributions = balances.map(account => account.balance.div(unlockedSupply).multipliedBy(100));
+  const totalDistribution = distributions.reduce((total, amount) => total.plus(amount), new BigNumber(0));
+  const totalNum = parseFloat(totalDistribution.toFixed(4));
+  // Sanity check on the combined distribution percentages of the top accounts
+  expect(totalNum).toBeGreaterThan(50);
+});
 
 test('get total supply', async () => {
   const { unlockedSupply, blockHeight } = await getUnlockedSupply();

--- a/test/aggregators/stacks-address.test.ts
+++ b/test/aggregators/stacks-address.test.ts
@@ -1,22 +1,18 @@
 import '../setup';
 import BN from 'bn.js';
-import BigNumber from 'bignumber.js';
 import StacksAddress from '../../lib/aggregators/stacks-address';
-import { getUnlockedSupply, getTopBalances } from '../../lib/core-db-pg/queries';
+import TopBalancesAggregator, { TopBalanceAccount } from '../../lib/aggregators/top-balances';
+import { getUnlockedSupply } from '../../lib/core-db-pg/queries';
+
 
 test('get top balances', async () => {
-  const { unlockedSupply } = await getUnlockedSupply();
-  const balances = await getTopBalances(500);
-  expect(balances).toBeTruthy();
+  const balances: TopBalanceAccount[] = await TopBalancesAggregator.fetch(500);
   expect(balances.length).toEqual(500);
   expect(balances[0].address).toBeTruthy();
-  expect(balances[0].balance.gt(1)).toBeTruthy();
-
-  const distributions = balances.map(account => account.balance.div(unlockedSupply).multipliedBy(100));
-  const totalDistribution = distributions.reduce((total, amount) => total.plus(amount), new BigNumber(0));
-  const totalNum = parseFloat(totalDistribution.toFixed(4));
+  expect(parseFloat(balances[0].balance)).toBeGreaterThan(1);
+  const totalDistribution = balances.reduce((total, account) => total + account.distribution, 0);
   // Sanity check on the combined distribution percentages of the top accounts
-  expect(totalNum).toBeGreaterThan(50);
+  expect(totalDistribution).toBeGreaterThan(50);
 });
 
 test('get total supply', async () => {

--- a/test/aggregators/top-balances.test.ts
+++ b/test/aggregators/top-balances.test.ts
@@ -1,0 +1,12 @@
+import '../setup';
+import TopBalancesAggregator, { TopBalanceAccount } from '../../lib/aggregators/top-balances';
+
+test('get top balances', async () => {
+  const balances: TopBalanceAccount[] = await TopBalancesAggregator.setter(500);
+  expect(balances.length).toEqual(500);
+  expect(balances[0].address).toBeTruthy();
+  expect(parseFloat(balances[0].balance)).toBeGreaterThan(1);
+  const totalDistribution = balances.reduce((total, account) => total + account.distribution, 0);
+  // Sanity check on the combined distribution percentages of the top accounts
+  expect(totalDistribution).toBeGreaterThan(50);
+});

--- a/test/aggregators/top-balances.test.ts
+++ b/test/aggregators/top-balances.test.ts
@@ -4,7 +4,8 @@ import TopBalancesAggregator, { TopBalanceAccount } from '../../lib/aggregators/
 test('get top balances', async () => {
   const balances: TopBalanceAccount[] = await TopBalancesAggregator.setter(500);
   expect(balances.length).toEqual(500);
-  expect(balances[0].address).toBeTruthy();
+  expect(balances[0].stxAddress).toBeTruthy();
+  expect(balances[0].btcAddress).toBeTruthy();
   expect(parseFloat(balances[0].balance)).toBeGreaterThan(1);
   const totalDistribution = balances.reduce((total, account) => total + account.distribution, 0);
   // Sanity check on the combined distribution percentages of the top accounts


### PR DESCRIPTION
Closes https://github.com/blockstack/blockstack-explorer/issues/189

Implements a query and API endpoint to retrieve accounts with the highest Stacks balances. 

API endpoint is `/api/v2/top-balances`. It returns 250 entries by default. The count can be specified with a query param, e.g. `/api/v2/top-balances?count=10`. The API controller sets a max count limit of 500.

Sample of the returned data:
```json
[
  {
    "stxAddress": "SP21HJA5D2N1ZDM9ZGTNQ5WYZFG6TTWN9GX2GTFWQ",
    "btcAddress": "1CxBfCcQXUfMbnavHmNp1fnhov4Jx3RW4Y",
    "balance": "39253561.000000",
    "distribution": 9.199323
  },
  {
    "stxAddress": "SP13HN8N68CFASWYBX6C78XP5HF50EHJENRYQHJ7S",
    "btcAddress": "17UxtH36S3AFM3odE8MQepqMFhNR1sKUWb",
    "balance": "18470754.944446",
    "distribution": 4.32874
  },
  {
    "stxAddress": "SP3WV3VC6GM1WF215SDHP0MESQ3BNXHB1N6TPB70S",
    "btcAddress": "1PmGQQgsE9dFHDVxPudQZ4YoqTonswgY1q",
    "balance": "16736152.796477",
    "distribution": 3.922225
  }
]
```

`balance` is the account's unlocked balance, and `distribution` is a percentage of the total unlocked supply. 


The query uses a `top-balances` aggregator, with a cache expiry of 10 minutes. 