### PR TITLE
dont fetch app.co apps for name page

### DIFF
--- a/lib/aggregators/name.ts
+++ b/lib/aggregators/name.ts
@@ -30,13 +30,15 @@ class NameAggregator extends Aggregator {
   }
 
   static async setter(name: string, historyPage = 0) {
-    const [person, nameRecord, appsList] = await Promise.all([
+    const [person, nameRecord] = await Promise.all([
       fetchName(name),
       getNameHistory(name),
-      AppsAggregator.fetch(),
     ]);
     let proofs;
-    let userApps = {};
+    const userApps = {
+      listed: [],
+      unlisted: [],
+    };
     if (person) {
       const { ownerAddress, profile } = person;
       proofs = await validateProofs(profile, ownerAddress, name);
@@ -53,7 +55,7 @@ class NameAggregator extends Aggregator {
         console.error(error);
         // move on
       }
-      userApps = this.getAppsArray(appsList, profile.apps);
+      // userApps = this.getAppsArray(appsList, profile.apps);
     }
     return {
       nameRecord,


### PR DESCRIPTION
We have a downstream issue with app.co's API - the endpoint to get Blockstack apps sorted by App Mining rewards is having some serious scaling issues. This PR simply removes the list of app icons from the name page, because it uses that API, and it's causing it to crash.

I am hotfixing this to staging, then to prod, because right now the name page is not working at all. I believe this is not a very critical feature, and it's fine to not display the app icons.