### PR TITLE
Fix v1 endpoints returning 404 rather than 500 on errors

### DIFF
--- a/controllers/api-controller.ts
+++ b/controllers/api-controller.ts
@@ -27,7 +27,7 @@ const respond = (dataFn: (req: Request, res?: Response) => Promise<Json> | Json)
       res.json(data);
     } catch (error) {
       logError(`Error handling request ${req.originalUrl}`, error);
-      res.status(404).json({ success: false });
+      res.status(500).json({ success: false });
     }
   }
 };


### PR DESCRIPTION
Related to https://github.com/blockstack/blockstack-explorer/issues/210

Corresponding front-end PR https://github.com/blockstack/blockstack-explorer/pull/211