### PR TITLE
feat: default aggregator redis cache 10 minutes

### DIFF
--- a/lib/aggregators/aggregator.ts
+++ b/lib/aggregators/aggregator.ts
@@ -208,7 +208,7 @@ export abstract class Aggregator<TResult extends Json, TArgs extends Json | void
   }
 
   expiry(args: TArgs): number | null {
-    return null;
+    return 10 * 60; // 10 minutes
   }
 }
 


### PR DESCRIPTION
Reference: https://github.com/blockstack/blockstack-explorer/issues/227#issuecomment-674968651

Redis cache behavior was defaulting to disabled for most aggregators. I think this was not intentionally. 