### PR TITLE
fix: change fee estimate multiple to 1.5

### DIFF
--- a/lib/aggregators/fee-estimate.ts
+++ b/lib/aggregators/fee-estimate.ts
@@ -10,7 +10,7 @@ class FeeEstimator extends Aggregator<number> {
     });
     return {
       shouldCacheValue: true,
-      value: Math.ceil(fastestFee * 1.25),
+      value: Math.ceil(fastestFee * 1.5),
     };
   }
 


### PR DESCRIPTION
We'd like to bump up our fee estimate for the Stacks Wallet by a bit, to help transactions get through appropriately. Previously, we took earn.com's estimate, and multiplied by 1.25. With this PR, we multiply by 1.5.